### PR TITLE
feat(voice-ui): 音声インテント履歴をUIに反映

### DIFF
--- a/src/features/voiceRecognition/components/VoiceCommandHistory/useVoiceCommandHistoryViewModel.test.tsx
+++ b/src/features/voiceRecognition/components/VoiceCommandHistory/useVoiceCommandHistoryViewModel.test.tsx
@@ -1,0 +1,85 @@
+/* @vitest-environment jsdom */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useVoiceCommandHistoryViewModel } from "./useVoiceCommandHistoryViewModel";
+import { useResearchStore } from "@/shared/stores/researchStore";
+
+function recordCommand({
+  id,
+  text,
+  pattern,
+  confidence,
+  timestamp,
+}: {
+  id: string;
+  text: string;
+  pattern: string;
+  confidence: number;
+  timestamp: Date;
+}) {
+  const { recordVoiceCommandResult } = useResearchStore.getState() as any;
+  recordVoiceCommandResult({
+    id,
+    originalText: text,
+    recognizedPattern: pattern,
+    confidence,
+    timestamp,
+    displayText: text,
+  });
+}
+
+describe("useVoiceCommandHistoryViewModel", () => {
+  beforeEach(() => {
+    useResearchStore.getState().reset();
+  });
+
+  it("履歴がない場合は非表示", () => {
+    const { result } = renderHook(() => useVoiceCommandHistoryViewModel());
+
+    expect(result.current.hasCommands).toBe(false);
+    expect(result.current.displayCommands).toHaveLength(0);
+  });
+
+  it("ストアの履歴を新しい順で整形する", () => {
+    recordCommand({
+      id: "voice-100",
+      text: "AIリスクを深掘りして",
+      pattern: "deepdive",
+      confidence: 0.84,
+      timestamp: new Date("2025-09-17T09:58:00.000Z"),
+    });
+
+    recordCommand({
+      id: "voice-101",
+      text: "最新の法規制を教えて",
+      pattern: "summary",
+      confidence: 0.66,
+      timestamp: new Date("2025-09-17T10:00:30.000Z"),
+    });
+
+    const { result } = renderHook(() => useVoiceCommandHistoryViewModel());
+
+    expect(result.current.hasCommands).toBe(true);
+    expect(result.current.displayCommands).toHaveLength(2);
+    expect(result.current.displayCommands[0]).toMatchObject({
+      id: "voice-101",
+      displayText: "最新の法規制を教えて",
+      recognizedPattern: "summary",
+      confidence: 0.66,
+    });
+    expect(result.current.displayCommands[1]).toMatchObject({
+      id: "voice-100",
+      recognizedPattern: "deepdive",
+    });
+
+    const expectedTime = new Date(
+      "2025-09-17T10:00:30.000Z",
+    ).toLocaleTimeString("ja-JP", {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+    expect(result.current.displayCommands[0]?.formattedTime).toBe(expectedTime);
+  });
+});

--- a/src/features/voiceRecognition/components/VoiceCommandHistory/useVoiceCommandHistoryViewModel.ts
+++ b/src/features/voiceRecognition/components/VoiceCommandHistory/useVoiceCommandHistoryViewModel.ts
@@ -2,35 +2,32 @@ import { useMemo } from "react";
 import { useResearchStore } from "@/shared/stores/researchStore";
 import type { VoiceCommandUI } from "../../types";
 
+function formatTimestamp(timestamp: Date | string): string {
+  const date = timestamp instanceof Date ? timestamp : new Date(timestamp);
+  return date.toLocaleTimeString("ja-JP", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
 export function useVoiceCommandHistoryViewModel() {
-  const { voiceCommand } = useResearchStore();
+  const voiceCommandHistory = useResearchStore(
+    (state) => state.voiceCommandHistory,
+  );
   const maxCommands = 5;
 
-  // モック履歴データ（実際の実装では専用ストアから取得）
-  const mockCommands: VoiceCommandUI[] = useMemo(() => {
-    if (!voiceCommand) return [];
-
-    return [
-      {
-        id: "1",
-        timestamp: new Date(),
-        originalText: voiceCommand,
-        recognizedPattern: "deepdive",
-        confidence: 0.95,
-        formattedTime: new Date().toLocaleTimeString("ja-JP", {
-          hour: "2-digit",
-          minute: "2-digit",
-          second: "2-digit",
-        }),
-        displayText: voiceCommand,
-      },
-    ];
-  }, [voiceCommand]);
-
-  const displayCommands = useMemo(
-    () => mockCommands.slice(-maxCommands).reverse(), // 新しいものを上に表示
-    [mockCommands, maxCommands],
-  );
+  const displayCommands: VoiceCommandUI[] = useMemo(() => {
+    return voiceCommandHistory.slice(0, maxCommands).map((entry) => ({
+      id: entry.id,
+      timestamp: entry.timestamp,
+      originalText: entry.originalText,
+      recognizedPattern: entry.recognizedPattern,
+      confidence: entry.confidence,
+      formattedTime: formatTimestamp(entry.timestamp),
+      displayText: entry.displayText ?? entry.originalText,
+    }));
+  }, [voiceCommandHistory, maxCommands]);
 
   const getCommandClassName = (command: VoiceCommandUI) => {
     const baseClass = "p-3 rounded-lg border text-sm";

--- a/src/features/voiceRecognition/hooks/useVoiceSSE.ts
+++ b/src/features/voiceRecognition/hooks/useVoiceSSE.ts
@@ -4,6 +4,7 @@ import {
   type VoiceSessionState,
   type PendingIntent,
 } from "@/shared/stores/voiceRecognitionStore";
+import { useResearchStore } from "@/shared/stores/researchStore";
 
 interface UseVoiceSSEOptions {
   sessionId: string | null;
@@ -46,6 +47,12 @@ export function useVoiceSSE({ sessionId, isPrimaryTab }: UseVoiceSSEOptions) {
   );
   const resetReconnectAttempt = useVoiceRecognitionStore(
     (state) => state.resetReconnectAttempt,
+  );
+  const setResearchPendingIntent = useResearchStore(
+    (state) => state.setPendingIntent,
+  );
+  const clearResearchPendingIntent = useResearchStore(
+    (state) => state.clearPendingIntent,
   );
 
   const reconnectAttemptRef = useRef(0);
@@ -155,6 +162,11 @@ export function useVoiceSSE({ sessionId, isPrimaryTab }: UseVoiceSSEOptions) {
       if (payload) {
         applySessionUpdate(payload);
         clearError();
+        if (payload.pendingIntent) {
+          setResearchPendingIntent(payload.pendingIntent);
+        } else {
+          clearResearchPendingIntent();
+        }
       }
     };
 
@@ -162,6 +174,7 @@ export function useVoiceSSE({ sessionId, isPrimaryTab }: UseVoiceSSEOptions) {
       const payload = parseMessage<PendingIntent>(event);
       if (payload) {
         setPendingIntent(payload);
+        setResearchPendingIntent(payload);
       }
     };
 

--- a/src/shared/ai/prompts/voiceIntentClassifier/index.ts
+++ b/src/shared/ai/prompts/voiceIntentClassifier/index.ts
@@ -17,14 +17,6 @@ type VoiceSessionSummary = {
   }>;
 };
 
-function safeJson(value: unknown): string {
-  try {
-    return JSON.stringify(value, null, 2);
-  } catch {
-    return String(value);
-  }
-}
-
 function buildSessionSummary(session: unknown): VoiceSessionSummary | null {
   if (!session || typeof session !== "object") return null;
 

--- a/src/shared/stores/voiceRecognitionStore.ts
+++ b/src/shared/stores/voiceRecognitionStore.ts
@@ -22,6 +22,7 @@ export interface VoiceSessionState {
   latestTranscript?: string;
   evaluationSummary?: string;
   lastUpdatedAt: string;
+  pendingIntent?: PendingIntent | null;
 }
 
 export interface PendingIntent {


### PR DESCRIPTION
## 概要
音声インテント判定結果を研究ストアとUIストアに連携し、SSE・UI の履歴表示を実データで更新できるようにしました。

## 変更内容
- [x] 研究ストアに intent/pendingIntent/履歴管理を追加
- [x] useVoiceSSE から intent_confirmation と session_update を研究ストアへ反映
- [x] VoiceRecognitionButton から解析結果を履歴へ保存し pendingIntent で信頼度更新
- [x] VoiceCommandHistory ViewModel とテストを実データ対応へ刷新

## テスト
- [x] ユニットテスト追加/更新
- [ ] 統合テスト追加/更新
- [x] 手動テストシナリオ

## チェックリスト
- [x] コードはプロジェクトのスタイルガイドに従っている
- [x] セルフレビューを実施した
- [x] 適切なテストを追加した
- [ ] ドキュメントを更新した（必要な場合）
- [x] Breaking Changeがない（ある場合は明記）

## 関連Issue
Fixes #17

## スクリーンショット（UI変更の場合）
なし

## その他
pendingIntent の信頼度で履歴が即時更新されるよう、SSE とストアの同期を入れています。
